### PR TITLE
fix: tolerate CoT wrappers in OpenAI-compatible responses

### DIFF
--- a/scripts/sync_stars.py
+++ b/scripts/sync_stars.py
@@ -12,6 +12,7 @@ GitHub Stars Index同步脚本 (JSON + Template 版)
 import os
 import sys
 import json
+import re
 import time
 import base64
 import logging


### PR DESCRIPTION
修复 MiniMax OpenAI 兼容接口下，`message.content` 含 `<think>...</think>` 时的 JSON 解析失败问题。

### 改动点
- 新增容错解析：先剥离 `<think>` 块，再尝试解析 JSON
- 兼容 ```json code fence``` 包裹场景
- 当内容不是纯 JSON 时，提取首个合法 JSON 对象
- 保持标准 OpenAI 返回行为不变（非 MiniMax 仍使用 `response_format={\"type\":\"json_object\"}`）

### 关联问题
- Closes #1