### PR TITLE
fix(ci): stabilize auto commit workflow and prevent push rejection

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -84,12 +84,13 @@ jobs:
       # ── 6. 提交变更到本仓库 ───────────────────────────────
       - name: 提交并推送变更
         run: |
+          set -e
+      
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
       
           git add data/stars.json
       
-          # 如果没有变化则直接退出
           if git diff --staged --quiet; then
             echo "✅ 无新内容，跳过提交"
             exit 0
@@ -97,9 +98,11 @@ jobs:
       
           git commit -m "🤖 自动更新 GitHub Stars 摘要 [$(date -u '+%Y-%m-%d %H:%M UTC')]"
       
-          # ⭐ 关键步骤：同步远程
-          git pull --rebase origin main
+          echo "🔄 同步远程最新代码..."
+          git fetch origin main
+          git rebase origin/main
       
+          echo "🚀 推送更新..."
           git push origin main
 
       # ── 7. 部署到 GitHub Pages ─────────────────────────────

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -86,12 +86,21 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+      
           git add data/stars.json
-          
-          # 如果没有变化则跳过 commit（避免空提交报错）
-          git diff --staged --quiet && echo "✅ 无新内容，跳过提交" || \
-            git commit -m "🤖 自动更新 GitHub Stars 摘要 [$(date -u '+%Y-%m-%d %H:%M UTC')]"
-          git push
+      
+          # 如果没有变化则直接退出
+          if git diff --staged --quiet; then
+            echo "✅ 无新内容，跳过提交"
+            exit 0
+          fi
+      
+          git commit -m "🤖 自动更新 GitHub Stars 摘要 [$(date -u '+%Y-%m-%d %H:%M UTC')]"
+      
+          # ⭐ 关键步骤：同步远程
+          git pull --rebase origin main
+      
+          git push origin main
 
       # ── 7. 部署到 GitHub Pages ─────────────────────────────
       - name: 部署到 GitHub Pages


### PR DESCRIPTION
当前 GitHub Actions 在自动更新 `data/stars.json` 后直接执行 `git push`，
当远程分支领先时会出现以下错误：
<img width="1020" height="328" alt="image" src="https://github.com/user-attachments/assets/bdbd35bc-f7be-4332-98ee-fd3e8669a73e" />
对提交逻辑进行了优化：

- 增加 `set -e` 提升脚本稳定性
- 在 push 前增加：
  - `git fetch origin main`
  - `git rebase origin/main`
- 显式指定 `git push origin main`
- 保留无变更时自动跳过提交逻辑

本修改不影响现有功能，仅增强提交稳定性。